### PR TITLE
Add specialised merge functions for `MonoidMap`.

### DIFF
--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2418,11 +2418,10 @@ unionWithA
     -> MonoidMap k v1
     -> MonoidMap k v2
     -> f (MonoidMap k v3)
-unionWithA f (MonoidMap m1) (MonoidMap m2) = MonoidMap <$> Map.mergeA
-    (traverseMaybeMissing $ \_ v1 -> guardNotNull <$> f v1 mempty)
-    (traverseMaybeMissing $ \_ v2 -> guardNotNull <$> f mempty v2)
-    (zipWithMaybeAMatched $ \_ v1 v2 -> guardNotNull <$> f v1 v2)
-    m1 m2
+unionWithA f = mergeA
+    (withNonNullLeftA f)
+    (withNonNullRightA f)
+    (withNonNullPairA f)
 
 --------------------------------------------------------------------------------
 -- Utilities

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1554,7 +1554,10 @@ commonSuffix
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-commonSuffix = intersectionWith C.commonSuffix
+commonSuffix = merge
+    (dropNonNull)
+    (dropNonNull)
+    (withNonNullPair C.commonSuffix)
 
 -- | Strips the /greatest common prefix/ from a pair of maps.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2460,16 +2460,6 @@ unionWithA f = mergeA
     (withNonNullPairA f)
 
 --------------------------------------------------------------------------------
--- Utilities
---------------------------------------------------------------------------------
-
-guardNotNull :: MonoidNull v => v -> Maybe v
-guardNotNull v
-    | C.null v = Nothing
-    | otherwise = Just v
-{-# INLINE guardNotNull #-}
-
---------------------------------------------------------------------------------
 -- Merging
 --------------------------------------------------------------------------------
 
@@ -2567,3 +2557,13 @@ withNonNullPairA
     => (v1 -> v2 -> f v3)
     -> Map.WhenMatched f k v1 v2 v3
 withNonNullPairA f = zipWithMaybeAMatched $ \_ v1 v2 -> guardNotNull <$> f v1 v2
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+guardNotNull :: MonoidNull v => v -> Maybe v
+guardNotNull v
+    | C.null v = Nothing
+    | otherwise = Just v
+{-# INLINE guardNotNull #-}

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2412,7 +2412,7 @@ power
 power m i = mapValues (`C.pow` i) m
 
 --------------------------------------------------------------------------------
--- Binary operations
+-- Intersection
 --------------------------------------------------------------------------------
 
 intersectionWith
@@ -2436,6 +2436,10 @@ intersectionWithA f = mergeA
     (dropNonNull)
     (dropNonNull)
     (withNonNullPairA f)
+
+--------------------------------------------------------------------------------
+-- Union
+--------------------------------------------------------------------------------
 
 unionWith
     :: (Ord k, Monoid v1, Monoid v2, MonoidNull v3)

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1458,7 +1458,10 @@ stripSuffix
     => MonoidMap k v
     -> MonoidMap k v
     -> Maybe (MonoidMap k v)
-stripSuffix = unionWithA C.stripSuffix
+stripSuffix = mergeA
+    (withNonNullLeftA C.stripSuffix)
+    (keepNonNull)
+    (withNonNullPairA C.stripSuffix)
 
 -- | Finds the /greatest common prefix/ of two maps.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1791,7 +1791,10 @@ overlap
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-overlap = intersectionWith C.overlap
+overlap = merge
+    (dropNonNull)
+    (dropNonNull)
+    (withNonNullPair C.overlap)
 
 -- | /Strips/ from the second map its /greatest prefix overlap/ with suffixes
 --   of the first map.

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2407,11 +2407,10 @@ unionWith
     -> MonoidMap k v1
     -> MonoidMap k v2
     -> MonoidMap k v3
-unionWith f (MonoidMap m1) (MonoidMap m2) = MonoidMap $ Map.merge
-    (mapMaybeMissing $ \_ v1 -> guardNotNull $ f v1 mempty)
-    (mapMaybeMissing $ \_ v2 -> guardNotNull $ f mempty v2)
-    (zipWithMaybeMatched $ \_ v1 v2 -> guardNotNull $ f v1 v2)
-    m1 m2
+unionWith f = merge
+    (withNonNullLeft f)
+    (withNonNullRight f)
+    (withNonNullPair f)
 
 unionWithA
     :: (Applicative f, Ord k, Monoid v1, Monoid v2, MonoidNull v3)

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2042,7 +2042,10 @@ gcd
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-gcd = intersectionWith C.gcd
+gcd = merge
+    (dropNonNull)
+    (dropNonNull)
+    (withNonNullPair C.gcd)
 
 --------------------------------------------------------------------------------
 -- Subtraction

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2095,7 +2095,10 @@ minus
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-minus = unionWith (C.~~)
+minus = merge
+    (keepNonNull)
+    (withNonNull C.invert)
+    (withNonNullPair (C.~~))
 
 -- | Performs /reductive subtraction/ of the second map from the first.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2385,11 +2385,10 @@ intersectionWith
     -> MonoidMap k v1
     -> MonoidMap k v2
     -> MonoidMap k v3
-intersectionWith f (MonoidMap m1) (MonoidMap m2) = MonoidMap $ Map.merge
-    dropMissing
-    dropMissing
-    (zipWithMaybeMatched $ \_ v1 v2 -> guardNotNull $ f v1 v2)
-    m1 m2
+intersectionWith f = merge
+    (dropNonNull)
+    (dropNonNull)
+    (withNonNullPair f)
 
 intersectionWithA
     :: (Applicative f, Ord k, MonoidNull v3)

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1060,7 +1060,10 @@ append
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-append = unionWith (<>)
+append = merge
+    (keepNonNull)
+    (keepNonNull)
+    (withNonNullPair (<>))
 
 --------------------------------------------------------------------------------
 -- Prefixes and suffixes

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1377,7 +1377,10 @@ stripPrefix
     => MonoidMap k v
     -> MonoidMap k v
     -> Maybe (MonoidMap k v)
-stripPrefix = unionWithA C.stripPrefix
+stripPrefix = mergeA
+    (withNonNullLeftA C.stripPrefix)
+    (keepNonNull)
+    (withNonNullPairA C.stripPrefix)
 
 -- | Strips a /suffix/ from a 'MonoidMap'.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2396,11 +2396,10 @@ intersectionWithA
     -> MonoidMap k v1
     -> MonoidMap k v2
     -> f (MonoidMap k v3)
-intersectionWithA f (MonoidMap m1) (MonoidMap m2) = MonoidMap <$> Map.mergeA
-    dropMissing
-    dropMissing
-    (zipWithMaybeAMatched $ \_ v1 v2 -> guardNotNull <$> f v1 v2)
-    m1 m2
+intersectionWithA f = mergeA
+    (dropNonNull)
+    (dropNonNull)
+    (withNonNullPairA f)
 
 unionWith
     :: (Ord k, Monoid v1, Monoid v2, MonoidNull v3)

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1506,7 +1506,10 @@ commonPrefix
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-commonPrefix = intersectionWith C.commonPrefix
+commonPrefix = merge
+    (dropNonNull)
+    (dropNonNull)
+    (withNonNullPair C.commonPrefix)
 
 -- | Finds the /greatest common suffix/ of two maps.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2215,7 +2215,10 @@ minusMaybe
     => MonoidMap k v
     -> MonoidMap k v
     -> Maybe (MonoidMap k v)
-minusMaybe = unionWithA (</>)
+minusMaybe = mergeA
+    (keepNonNull)
+    (withNonNullRightA (</>))
+    (withNonNullPairA (</>))
 
 -- | Performs /monus subtraction/ of the second map from the first.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1852,7 +1852,10 @@ stripPrefixOverlap
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-stripPrefixOverlap = unionWith C.stripPrefixOverlap
+stripPrefixOverlap = merge
+    (dropNonNull)
+    (keepNonNull)
+    (withNonNullPair C.stripPrefixOverlap)
 
 -- | /Strips/ from the second map its /greatest suffix overlap/ with prefixes
 --   of the first map.

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -1913,7 +1913,10 @@ stripSuffixOverlap
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-stripSuffixOverlap = unionWith C.stripSuffixOverlap
+stripSuffixOverlap = merge
+    (dropNonNull)
+    (keepNonNull)
+    (withNonNullPair C.stripSuffixOverlap)
 
 -- | Finds the /greatest overlap/ of two maps and /strips/ it from both maps.
 --

--- a/src/internal/Data/Total/MonoidMap/Internal.hs
+++ b/src/internal/Data/Total/MonoidMap/Internal.hs
@@ -2321,7 +2321,10 @@ monus
     => MonoidMap k v
     -> MonoidMap k v
     -> MonoidMap k v
-monus = unionWith (<\>)
+monus = merge
+    (keepNonNull)
+    (dropNonNull)
+    (withNonNullPair (<\>))
 
 --------------------------------------------------------------------------------
 -- Inversion


### PR DESCRIPTION
This PR:
- adds specialised merge functions for `MonoidMap`.
- uses these functions to re-implement most binary operations.
