### PR TITLE
Update dependencies.

### DIFF
--- a/src/test/Data/Total/MonoidMap/ClassSpec.hs
+++ b/src/test/Data/Total/MonoidMap/ClassSpec.hs
@@ -42,8 +42,7 @@ import Test.QuickCheck.Classes.Group
 import Test.QuickCheck.Classes.Hspec
     ( testLawsMany )
 import Test.QuickCheck.Classes.Monoid.GCD
-    ( cancellativeGCDMonoidLaws
-    , gcdMonoidLaws
+    ( gcdMonoidLaws
     , leftGCDMonoidLaws
     , overlappingGCDMonoidLaws
     , rightGCDMonoidLaws
@@ -172,8 +171,7 @@ specLawsFor keyType = do
             , showReadLaws
             ]
         testLawsMany @(MonoidMap k (Sum Natural))
-            [ cancellativeGCDMonoidLaws
-            , cancellativeLaws
+            [ cancellativeLaws
             , commutativeLaws
             , eqLaws
             , gcdMonoidLaws
@@ -276,8 +274,7 @@ specLawsFor keyType = do
             , showReadLaws
             ]
         testLawsMany @(MonoidMap k (MonoidMap k (Sum Natural)))
-            [ cancellativeGCDMonoidLaws
-            , cancellativeLaws
+            [ cancellativeLaws
             , commutativeLaws
             , eqLaws
             , gcdMonoidLaws

--- a/total-monoidal-maps.cabal
+++ b/total-monoidal-maps.cabal
@@ -26,7 +26,7 @@ common dependency-groups
 common dependency-hspec
     build-depends:hspec                         >= 2.10.9     && < 2.11
 common dependency-monoid-subclasses
-    build-depends:monoid-subclasses             >= 1.2.2      && < 1.3
+    build-depends:monoid-subclasses             >= 1.2.3      && < 1.3
 common dependency-nothunks
     build-depends:nothunks                      >= 0.1.3      && < 0.2
 common dependency-pretty-show
@@ -40,7 +40,7 @@ common dependency-quickcheck-groups
 common dependency-quickcheck-instances
     build-depends:quickcheck-instances          >= 0.3.28     && < 0.4
 common dependency-quickcheck-monoid-subclasses
-    build-depends:quickcheck-monoid-subclasses  >= 0.1.0.0    && < 0.3
+    build-depends:quickcheck-monoid-subclasses  >= 0.3.0.0    && < 0.4
 common dependency-tasty-bench
     build-depends:tasty-bench                   >= 0.3.2      && < 0.4
 common dependency-tasty-hunit


### PR DESCRIPTION
Update lower bounds for the following libraries:

- `monoid-subclasses`
- `quickcheck-monoid-subclasses`

The following function was removed from `quickcheck-monoid-subclasses`:

- `cancellativeGCDMonoidLaws`